### PR TITLE
Add Load in watts and Load Percentage to webgui settings page

### DIFF
--- a/Apcupsd-x86_64.plg
+++ b/Apcupsd-x86_64.plg
@@ -138,6 +138,31 @@ apcupsd.php.
       $timeleft = substr($apcaccessoutput, $timeleftstartpos, $timeleftendpos-$timeleftstartpos);
       $timeleftint = preg_replace('/[^0-9\.]/', '', $timeleft);
       $timeleftcolour = (round($timeleft) <= 5 ? 'red' : 'green');
+
+      //loadpct
+      $loadpctstartpos = strpos($apcaccessoutput, "LOADPCT  :") +11;
+      $loadpctendpos = strpos($apcaccessoutput, "\n", $loadpctstartpos);
+      $loadpct = substr($apcaccessoutput, $loadpctstartpos, $loadpctendpos-$loadpctstartpos);
+      $loadpctint = preg_replace('/[^0-9\.]/', '', $loadpct);
+
+      //nompower
+      $nompowerstartpos = strpos($apcaccessoutput, "NOMPOWER :") +11;
+      $nompowerendpos = strpos($apcaccessoutput, "\n", $nompowerstartpos);
+      $nompower = substr($apcaccessoutput, $nompowerstartpos, $nompowerendpos-$nompowerstartpos);
+      $nompowerint = preg_replace('/[^0-9\.]/', '', $nompower);
+      
+      //load
+      if ($nompowerstartpos != "11")
+      {
+       $load=($loadpctint/100)*$nompowerint;
+       $loadcolour='green';
+      }
+      else 
+      {
+       $load="N/A";
+       $loadcolour='red';
+      }
+      $load .= " Watts";
      }     
   }
   
@@ -199,6 +224,12 @@ apcupsd.php.
           </td>
           <td>
              <? if ($status=="ONLINE" || $status=="ONBATT"): ?><span class="status_head">Time Left: </span><span class="<?=$timeleftcolour;?>"><?=$timeleft;?></span><? endif; ?>
+          </td>
+          <td>
+             <? if ($status=="ONLINE" || $status=="ONBATT"): ?><span class="status_head">Load: </span><span class="<?=$loadcolour;?>"><?=$load;?></span><? endif; ?>
+          </td>
+          <td>
+             <? if ($status=="ONLINE" || $status=="ONBATT"): ?><span class="status_head">Load %: </span><span class="<?=$loadcolour;?>"><?=$loadpct;?></span><? endif; ?>
           </td>
          </tr>
        </table>


### PR DESCRIPTION
This will display load percentage and the load in watts that the ups is under on the settings page.  If the ups doesn't have the nompower variable it will diplay a red N/A for load.  Could be updated so a user could input  the known nompower for their ups.

![screenshot from 2014-09-06 01 40 45](https://cloud.githubusercontent.com/assets/6558393/4174604/b7e346f4-359a-11e4-820c-28ded2ca9b2a.png)
